### PR TITLE
Loaded integrations addons refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,8 @@ dist
 dist/*
 dist/**
 build
+env
 *.env
 **.env
+*.ipynb
+prep_dev_env.py

--- a/helloworld_core/helloworld_full.py
+++ b/helloworld_core/helloworld_full.py
@@ -9,16 +9,32 @@ import textwrap
 from collections import OrderedDict
 import requests
 from copy import deepcopy
-from IPython.core.magic import (Magics, magics_class, line_magic, cell_magic, line_cell_magic)
+from IPython.core.magic import (
+    Magics,
+    magics_class,
+    line_magic,
+    cell_magic,
+    line_cell_magic,
+)
 from IPython.core.display import HTML
-from IPython.display import display_html, display, Markdown, Javascript, FileLink, FileLinks, Image
+from IPython.display import (
+    display_html,
+    display,
+    Markdown,
+    Javascript,
+    FileLink,
+    FileLinks,
+    Image,
+)
 import pandas as pd
+
 # Widgets
 from ipywidgets import GridspecLayout, widgets
 import jupyter_integrations_utility as jiu
 
 from helloworld_core._version import __desc__
 from addon_core import Addon
+
 
 @magics_class
 class Helloworld(Addon):
@@ -29,44 +45,51 @@ class Helloworld(Addon):
     custom_evars = []
 
     # Addons required to be loaded
-    req_addons = ['helloworld', 'display', 'persist', 'profile', 'sharedfunc', 'vis', 'namedpw', 'feat', 'pyvis', 'pivot']
-    req_full_addons = ['display', 'namedpw']
+    req_addons = [
+        "helloworld",
+        "display",
+        "persist",
+        "profile",
+        "sharedfunc",
+        "vis",
+        "namedpw",
+        "feat",
+        "pyvis",
+        "pivot",
+    ]
+    req_full_addons = ["display", "namedpw"]
     custom_allowed_set_opts = []
 
-
     myopts = {}
-#    myopts['profile_max_rows_full'] = [10000, "Row threshold for doing full analysis. Over there and we default to minimal analysis with a warning"]
+    #    myopts['profile_max_rows_full'] = [10000, "Row threshold for doing full analysis. Over there and we default to minimal analysis with a warning"]
 
-
-    def __init__(self, shell, debug=False,  *args, **kwargs):
+    def __init__(self, shell, debug=False, *args, **kwargs):
         super(Helloworld, self).__init__(shell, debug=debug)
         self.debug = debug
 
-        #Add local variables to opts dict
+        # Add local variables to opts dict
         for k in self.myopts.keys():
             self.opts[k] = self.myopts[k]
         self.load_env(self.custom_evars)
-        if 'jupyter_loaded_addons' not in self.ipy.user_ns:
-            self.ipy.user_ns['jupyter_loaded_addons'] = {}
-        self.ipy.user_ns['jupyter_loaded_addons']['helloworld'] = 'helloworld_full'
+        if "jupyter_loaded_addons" not in self.ipy.user_ns:
+            self.ipy.user_ns["jupyter_loaded_addons"] = {}
+        self.ipy.user_ns["jupyter_loaded_addons"]["helloworld"] = "helloworld_full"
         self.check_req_addons()
         # Loading doc_and_batch
-#        self.ipy.ex("from helloworld_core.doc_and_batch import *\n")
-#        self.ipy.ex("from jupyter_integrations_utility.doc_and_batch import *\n")
+        #        self.ipy.ex("from helloworld_core.doc_and_batch import *\n")
+        #        self.ipy.ex("from jupyter_integrations_utility.doc_and_batch import *\n")
         self.ipy.ex("from jupyter_integrations_utility.funcdoc import *\n")
         self.ipy.ex("from jupyter_integrations_utility.batchquery import *\n")
 
-
-
-#        shell.user_ns['helloworld_var'] = self.creation_name
+    #        shell.user_ns['helloworld_var'] = self.creation_name
 
     # We will maybe have to load helloworld  first
     def check_req_addons(self):
         for addon in self.req_addons:
             chk = addon
-            if 'jupyter_loaded_addons' not in self.ipy.user_ns:
-                self.ipy.user_ns['jupyter_loaded_addons'] = {}
-            if chk not in self.ipy.user_ns['jupyter_loaded_addons'].keys():
+            if "jupyter_loaded_addons" not in self.ipy.user_ns:
+                self.ipy.user_ns["jupyter_loaded_addons"] = {}
+            if chk not in self.ipy.user_ns["jupyter_loaded_addons"].keys():
                 if self.debug:
                     print("%s not found in user_ns - Running" % chk)
                 objname = addon.capitalize()
@@ -81,86 +104,84 @@ class Helloworld(Addon):
                 if self.debug:
                     print(runcode)
                 res = self.ipy.ex(runcode)
-                self.ipy.user_ns['jupyter_loaded_addons'][chk] = varobjname
+                self.ipy.user_ns["jupyter_loaded_addons"][chk] = varobjname
             else:
                 if self.debug:
                     print("%s found in user_ns - Not loading" % chk)
 
+    def list_installed_integrations_and_addons(self):
+        """Generate markdown tables for the loaded integrations and addons in the user's ipy namespace
 
+        Returns:
+            final_markdown : str - a markdown-ready string containing the tables of loaded integrations and addons
+        """
+        integrations = list(self.ipy.user_ns["jupyter_loaded_integrations"].keys())
+        addons = list(self.ipy.user_ns["jupyter_loaded_addons"].keys())
 
+        additional_help_md = "Additional help for each integration and addon can be found by running the magic string for each integration or addon\n"
 
+        installed_integrations_md = (
+            "### Installed integrations\n"
+            "-------------------------------------\n"
+            "| Integration | Desc | Version |\n"
+            "| ----------- | ---- | ------- |\n"
+        )
 
+        for integration in integrations:
+            base_name = self.ipy.user_ns["jupyter_loaded_integrations"][integration]
+            magic_name = self.ipy.user_ns[base_name].magic_name
+            description = "<br>".join(
+                textwrap.wrap(self.ipy.user_ns[base_name].retCustomDesc(), 70)
+            )
+            installed_integrations_md += (
+                f"| %{magic_name} | {description} | coming soon |\n"
+            )
 
-    def listIntsAdsMD(self):
-        myout = ""
-        myout += "\n"
-        myout += "Additional help for each integration and addon can be found by running the magic string for each integration or addon\n"
-        myout += "\n"
-        myout += "### Installed Integrations and Addons\n"
-        myout += "---------------\n"
-        myout += "| Integration | Desc |   | Addon | Desc |\n"
-        myout += "| ------ | ------ | --- | ----- | ---------|\n"
+        installed_addons_md = (
+            "### Installed addons\n"
+            "-------------------------------------\n"
+            "| Addon | Desc | Version |\n"
+            "| ----- | ---- | ------- |\n"
+        )
 
-        myints = list(self.ipy.user_ns['jupyter_loaded_integrations'].keys())
-        myadds = list(self.ipy.user_ns['jupyter_loaded_addons'].keys())
-        for i in range(max(len(myints), len(myadds))):
-            try:
-                cn = self.ipy.user_ns['jupyter_loaded_integrations'][myints[i]]
-                mn = self.ipy.user_ns[cn].magic_name
-                myintdesc = self.ipy.user_ns[cn].retCustomDesc()
-                myintdesc = "<br>".join(textwrap.wrap(myintdesc, 40))
+        for addon in addons:
+            base_name = self.ipy.user_ns["jupyter_loaded_addons"][addon]
+            magic_name = self.ipy.user_ns[base_name].magic_name
+            description = "<br>".join(
+                textwrap.wrap(self.ipy.user_ns[base_name].retCustomDesc(), 70)
+            )
+            installed_addons_md += f"| %{magic_name} | {description} | coming soon |\n"
 
-                myint = "%" + mn
-                myintstatus = str(True)
-            except:
-                myint = " "
-                myintstatus = " "
-                myintdesc = " "
+        final_markdown = "\n".join(
+            [additional_help_md, installed_integrations_md, installed_addons_md]
+        )
 
-            try:
-                cn = self.ipy.user_ns['jupyter_loaded_addons'][myadds[i]]
-                mn = self.ipy.user_ns[cn].magic_name
-                myadddesc = self.ipy.user_ns[cn].retCustomDesc()
-                myadddesc = "<br>".join(textwrap.wrap(myadddesc, 40))
-                myadd = "%" + mn
-                myaddstatus = str(True)
-            except:
-                myadd = " "
-                myaddstatus = " "
-                myadddesc = " "
-            myout += "| %s | %s |   | %s | %s|\n" % (myint, myintdesc, myadd, myadddesc)
-        myout += "\n"
-        return myout
+        return final_markdown
 
-    def customHelp(self, curout):
+    def customHelp(self, current_output):
         n = self.magic_name
         m = "%" + n
         mq = "%" + m
 
-        table_header = "| Magic | Description |\n"
-        table_header += "| -------- | ----- |\n"
+        custom_help_markdown = (
+            f"{current_output}\n"
+            f"### {m} line magics\n"
+            "----------------------\n"
+            "| Magic | Description |\n"
+            "| ----- | ----------- |\n"
+            f"| {m + ' batch'} | Print the batch_query_help() (Same as typing batch_query_help() )  |\n"
+            f"| {m + ' func'} | Print the function_doc_help() (Same as typing function_doc_help() )  |\n"
+            f"| {m + ' go'} | Put the helloworld go (defined in the variable hello_go) into the next cell. You can specify this in an py file in the .ipython profile_default startup folder |\n"
+            "\n\n\n"
+            f"{self.list_installed_integrations_and_addons()}"
+        )
 
-        out = curout
-
-        out += "\n"
-        out += f"### {m} line magics\n"
-        out += "---------------\n"
-        out += table_header
-        out += f"| {m + ' batch'} | Print the batch_query_help() (Same as typing batch_query_help() )  |\n"
-        out += f"| {m + ' func'} | Print the function_doc_help() (Same as typing function_doc_help() )  |\n"
-        out += f"| {m + ' go'} | Put the helloworld go (defined in the variable hello_go) into the next cell. You can specify this in an py file in the .ipython profile_default startup folder |\n"
-        out += "\n\n"
-        out += "\n"
-        out += self.listIntsAdsMD()
-
-        return out
+        return custom_help_markdown
 
     def retCustomDesc(self):
         return __desc__
 
-
     def fillGo(self, varname):
-
         fullvar = f"hello_{varname}"
 
         if fullvar in self.ipy.user_ns:
@@ -170,18 +191,18 @@ class Helloworld(Addon):
         else:
             print("We shouldn't get here")
 
-
-
     # This is the magic name.
     @line_cell_magic
     def helloworld(self, line, cell=None):
         if self.debug:
-           print("line: %s" % line)
-           print("cell: %s" % cell)
+            print("line: %s" % line)
+            print("cell: %s" % cell)
         line = line.replace("\r", "")
         if cell is None:
             line_handled = self.handleLine(line)
-            if not line_handled: # We based on this we can do custom things for integrations.
+            if (
+                not line_handled
+            ):  # We based on this we can do custom things for integrations.
                 if line.lower().strip() == "go":
                     self.fillGo("go")
                 elif line.lower().strip() == "batch":
@@ -191,9 +212,10 @@ class Helloworld(Addon):
                 elif f"hello_{line.lower().strip()}" in self.ipy.user_ns:
                     self.fillGo(line.lower().strip())
                 else:
-                    print("I am sorry, I don't know what you want to do with your line magic, try just %" + self.name_str + " for help options")
-        else: # This is run is the cell is not none, thus it's a cell to process  - For us, that means a query
+                    print(
+                        "I am sorry, I don't know what you want to do with your line magic, try just %"
+                        + self.name_str
+                        + " for help options"
+                    )
+        else:  # This is run is the cell is not none, thus it's a cell to process  - For us, that means a query
             print("No Cell Magic for %s" % self.name_str)
-
-
-


### PR DESCRIPTION
In this PR I refactored how the markdown is generated for when a user runs the helloworld magic, and I split out the loaded integrations and loaded addons into separate tables (but still organized under the same heading). There's no real functional changes here other than that, and a touch of code formatting. Pull this branch and run it so you can see what I changed!